### PR TITLE
Tags UI

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -1,1 +1,4 @@
+---
+tags: [testing, 'good']
+---
 a test is a good thing.

--- a/lib/bl/app_state.dart
+++ b/lib/bl/app_state.dart
@@ -49,6 +49,14 @@ class AppState extends ChangeNotifier {
     store.updateNote(old, _current);
   }
 
+  void updateCurrentRemoveTag(String tag) {
+    final old = _current;
+    final updatedTags = _current.tags..remove(tag);
+    _current = _current.copyWith(tags: updatedTags);
+    store.updateNote(old, _current);
+    notifyListeners();
+  }
+
   void search(String term) {
     _currentSearchTerm = term;
     store.filter((term != null && term.isNotEmpty) ? SearchFilter(term) : null);

--- a/lib/bl/app_state.dart
+++ b/lib/bl/app_state.dart
@@ -57,6 +57,14 @@ class AppState extends ChangeNotifier {
     notifyListeners();
   }
 
+  void updateCurrentAddTag(String tag) {
+    final old = _current;
+    final updatedTags = _current.tags..add(tag);
+    _current = _current.copyWith(tags: updatedTags);
+    store.updateNote(old, _current);
+    notifyListeners();
+  }
+
   void search(String term) {
     _currentSearchTerm = term;
     store.filter((term != null && term.isNotEmpty) ? SearchFilter(term) : null);

--- a/lib/bl/localdir_note_store.dart
+++ b/lib/bl/localdir_note_store.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:meta/meta.dart';
@@ -48,7 +49,12 @@ class LocalDirNoteStore implements NoteStore {
 
   @override
   void saveNote(Note note) {
-    File(path.join(notesDir.path, note.filename)).writeAsString(note.content);
+    String fileContent = '';
+    if (note.tags.isNotEmpty) {
+      fileContent = ('---\ntags: ${_listAsYamlString(note.tags)}\n---\n');
+    }
+    fileContent += note.content;
+    File(path.join(notesDir.path, note.filename)).writeAsString(fileContent);
   }
 
   @override
@@ -111,5 +117,9 @@ class LocalDirNoteStore implements NoteStore {
     } else {
       return null;
     }
+  }
+
+  String _listAsYamlString(List<String> list) {
+    return jsonEncode(list);
   }
 }

--- a/lib/bl/localdir_note_store.dart
+++ b/lib/bl/localdir_note_store.dart
@@ -93,7 +93,7 @@ class LocalDirNoteStore implements NoteStore {
     final title =
         path.basenameWithoutExtension(f.absolute.path).replaceAll('_', ' ');
 
-    if (content.startsWith('---')) {
+    if (content?.startsWith('---') ?? false) {
       final fmDoc = fm.parse(content);
 
       return Note(

--- a/lib/bl/localdir_note_store.dart
+++ b/lib/bl/localdir_note_store.dart
@@ -1,12 +1,13 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:meta/meta.dart';
-import 'package:rxdart/rxdart.dart';
-import 'package:path/path.dart' as path;
 import 'package:front_matter/front_matter.dart' as fm;
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as path;
+import 'package:rxdart/rxdart.dart';
 import 'package:yaml/yaml.dart' as yaml;
 
+import '../extensions.dart';
 import 'filters.dart';
 import 'note.dart';
 import 'note_store.dart';
@@ -93,14 +94,19 @@ class LocalDirNoteStore implements NoteStore {
     final title =
         path.basenameWithoutExtension(f.absolute.path).replaceAll('_', ' ');
 
+    return parseNoteText(filename, title, content);
+  }
+
+  Future<Note> parseNoteText(
+      String filename, String title, String content) async {
     if (content?.startsWith('---') ?? false) {
       final fmDoc = fm.parse(content);
 
       return Note(
         filename: filename,
-        title: fmDoc.data['title'] as String ?? title,
+        title: fmDoc.getData('title') as String ?? title,
         content: fmDoc.content,
-        tags: _asStringList(fmDoc.data['tags']) ?? [],
+        tags: _asStringList(fmDoc.getData('tags')) ?? [],
       );
     } else {
       return Note(

--- a/lib/bl/note.dart
+++ b/lib/bl/note.dart
@@ -69,6 +69,9 @@ class Note {
 
   // enforce rules on what a title can be
   static String _titleFromText(String text) {
+    if (text == null || text.isEmpty) {
+      return null;
+    }
     final maxTitleLength = 80;
     final title = text
         .substring(0, math.min(maxTitleLength, text.length))

--- a/lib/extensions.dart
+++ b/lib/extensions.dart
@@ -1,0 +1,7 @@
+import 'package:front_matter/front_matter.dart';
+
+extension FrontMatterDocE on FrontMatterDocument {
+  dynamic getData(String key) {
+    return (data != null) ? data[key] : null;
+  }
+}

--- a/lib/ui/note_widget.dart
+++ b/lib/ui/note_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:markdown/markdown.dart' as md;
+import 'package:mknotes/ui/tag_list.dart';
 import 'package:provider/provider.dart';
 
 import '../bl/app_state.dart';
@@ -48,11 +49,17 @@ class _NoteContentState extends State<NoteContent> {
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.all(8.0),
-        child: _contentWidget(
-            context,
-            context.watch<AppState>().current?.content ?? '',
-            _appState.edit,
-            _appState.searchTerm),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TagList(tags: context.watch<AppState>().current?.tags),
+            _contentWidget(
+                context,
+                context.watch<AppState>().current?.content ?? '',
+                _appState.edit,
+                _appState.searchTerm),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/note_widget.dart
+++ b/lib/ui/note_widget.dart
@@ -56,8 +56,10 @@ class _NoteContentState extends State<NoteContent> {
             TagList(
               tags: appState.current?.tags,
               editable: appState.edit,
+              onAddTag: (tag) => appState.updateCurrentAddTag(tag),
               onDeleteTag: (tag) => appState.updateCurrentRemoveTag(tag),
             ),
+            Divider(),
             _contentWidget(
                 context,
                 context.watch<AppState>().current?.content ?? '',

--- a/lib/ui/note_widget.dart
+++ b/lib/ui/note_widget.dart
@@ -46,13 +46,18 @@ class _NoteContentState extends State<NoteContent> {
 
   @override
   Widget build(BuildContext context) {
+    final appState = context.watch<AppState>();
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            TagList(tags: context.watch<AppState>().current?.tags),
+            TagList(
+              tags: appState.current?.tags,
+              editable: appState.edit,
+              onDeleteTag: (tag) => appState.updateCurrentRemoveTag(tag),
+            ),
             _contentWidget(
                 context,
                 context.watch<AppState>().current?.content ?? '',

--- a/lib/ui/tag_list.dart
+++ b/lib/ui/tag_list.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class TagList extends StatelessWidget {
+  final List<String> tags;
+
+  const TagList({Key key, this.tags = const []}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: tags?.map<Widget>((e) => Chip(label: Text(e)))?.toList() ?? [],
+    );
+  }
+}

--- a/lib/ui/tag_list.dart
+++ b/lib/ui/tag_list.dart
@@ -2,17 +2,22 @@ import 'package:flutter/material.dart';
 
 class TagList extends StatelessWidget {
   final List<String> tags;
+  final void Function(String) onAddTag;
   final void Function(String) onDeleteTag;
   final bool editable;
 
   const TagList(
-      {Key key, this.tags = const [], this.onDeleteTag, this.editable})
+      {Key key,
+      this.tags = const [],
+      this.onDeleteTag,
+      this.editable,
+      this.onAddTag})
       : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: tags
+    return Row(children: [
+      ...tags
               ?.map<Widget>((e) => Padding(
                     padding: const EdgeInsets.only(right: 4.0),
                     child: Chip(
@@ -22,6 +27,33 @@ class TagList extends StatelessWidget {
                   ))
               ?.toList() ??
           [],
+      Padding(
+        padding: const EdgeInsets.only(left: 8),
+        child: editable
+            ? AddTagField(
+                onAddTag: onAddTag,
+              )
+            : Container(),
+      )
+    ]);
+  }
+}
+
+class AddTagField extends StatelessWidget {
+  final void Function(String) onAddTag;
+
+  const AddTagField({Key key, @required this.onAddTag}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 100,
+      child: TextField(
+        autofocus: true,
+        maxLines: 1,
+        decoration: InputDecoration(hintText: 'new tag'),
+        onSubmitted: onAddTag,
+      ),
     );
   }
 }

--- a/lib/ui/tag_list.dart
+++ b/lib/ui/tag_list.dart
@@ -8,7 +8,13 @@ class TagList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
-      children: tags?.map<Widget>((e) => Chip(label: Text(e)))?.toList() ?? [],
+      children: tags
+              ?.map<Widget>((e) => Padding(
+                    padding: const EdgeInsets.only(right: 4.0),
+                    child: Chip(label: Text(e)),
+                  ))
+              ?.toList() ??
+          [],
     );
   }
 }

--- a/lib/ui/tag_list.dart
+++ b/lib/ui/tag_list.dart
@@ -2,8 +2,12 @@ import 'package:flutter/material.dart';
 
 class TagList extends StatelessWidget {
   final List<String> tags;
+  final void Function(String) onDeleteTag;
+  final bool editable;
 
-  const TagList({Key key, this.tags = const []}) : super(key: key);
+  const TagList(
+      {Key key, this.tags = const [], this.onDeleteTag, this.editable})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -11,7 +15,10 @@ class TagList extends StatelessWidget {
       children: tags
               ?.map<Widget>((e) => Padding(
                     padding: const EdgeInsets.only(right: 4.0),
-                    child: Chip(label: Text(e)),
+                    child: Chip(
+                      label: Text(e),
+                      onDeleted: editable ? (() => onDeleteTag(e)) : null,
+                    ),
                   ))
               ?.toList() ??
           [],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -130,6 +130,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  front_matter:
+    dependency: "direct main"
+    description:
+      name: front_matter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
       url: git://github.com/google/flutter-desktop-embedding.git
       path: plugins/window_size
       ref: master
+  front_matter: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/bl/filters_test.dart
+++ b/test/bl/filters_test.dart
@@ -1,25 +1,23 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:mknotes/bl/filters.dart';
 import 'package:mknotes/bl/note.dart';
 
 void main() {
-  testWidgets('filter finds match no match in note title or content',
-      (tester) async {
+  test('filter finds match no match in note title or content', () async {
     final filter = SearchFilter('foo');
     final testNote =
         Note(filename: 'test.md', content: 'nothing really.', title: 'test');
 
     expect(filter.apply(testNote), false);
   });
-  testWidgets('filter finds match in note title', (tester) async {
+  test('filter finds match in note title', () async {
     final filter = SearchFilter('test');
     final testNote =
         Note(filename: 'test.md', content: 'nothing really.', title: 'test');
 
     expect(filter.apply(testNote), true);
   });
-  testWidgets('filter finds match from partial in note content',
-      (tester) async {
+  test('filter finds match from partial in note content', () async {
     final filter = SearchFilter('real');
     final testNote =
         Note(filename: 'test.md', content: 'nothing really.', title: 'test');


### PR DESCRIPTION
Add UI for displaying and managing tags for a note. Tags are optional, so no UI is displayed for notes that don't have any tags.
Tags are stored in yaml frontmatter for local note text files.

![Screenshot 2020-09-10 at 09 08 35](https://user-images.githubusercontent.com/71999/92663671-3a063600-f345-11ea-9555-821fed34a06f.png)
